### PR TITLE
Chore: настроила вывод данных в полях со временем и датой в заявке

### DIFF
--- a/hrspace/api/serializers.py
+++ b/hrspace/api/serializers.py
@@ -34,6 +34,10 @@ class OrderSerializer(serializers.ModelSerializer):
     award = serializers.StringRelatedField()
     format_interview = serializers.StringRelatedField()
     amount_of_hr = serializers.StringRelatedField()
+    start_work_day = serializers.TimeField(format='%#H.%M')
+    end_work_day = serializers.TimeField(format='%#H.%M')
+    start_work = serializers.DateField(format='%d.%m.%Y')
+    start_interview = serializers.DateField(format='%d.%m.%Y')
 
     class Meta:
         model = Order

--- a/hrspace/hrspace/settings.py
+++ b/hrspace/hrspace/settings.py
@@ -116,7 +116,7 @@ SPECTACULAR_SETTINGS = {
 }
 
 
-LANGUAGE_CODE = 'ru-ru'
+LANGUAGE_CODE = 'ru-RU'
 
 TIME_ZONE = 'Europe/Moscow'
 


### PR DESCRIPTION
Скорректировала поля 'start_work_day', 'end_work_day',  'start_work', 'start_interview' под фронтенд (например, чтобы время высвечивалось в формате 8.00 или 8.30, а дата, допустим, 02.04.2024)
P.S. пока меняла параметры времени в settings.py забыла обратно поменять LANGUAGE_CODE, но вроде это никак не отразилось на выводе данных или поменять обратно при мердже